### PR TITLE
Centralize project metadata

### DIFF
--- a/pyietflib/__init__.py
+++ b/pyietflib/__init__.py
@@ -4,22 +4,8 @@
 defined data streams into objects that may be used directly in Python,
 and the written as fully compliant data streams.
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
-
+from .__meta__ import (__version__, __author__, __copyright__, __license__)
 
 from .headers import *
 from .generators import *

--- a/pyietflib/__meta__.py
+++ b/pyietflib/__meta__.py
@@ -1,0 +1,19 @@
+# -*- coding: UTF-8 -*-
+"""Contains all project-wide metadata."""
+
+__version__ = '1.0'
+__author__ = ('Lance Finn Helsten',)
+__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
+__license__ = """
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""

--- a/pyietflib/generators.py
+++ b/pyietflib/generators.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """Collection of all pyietflib generator creation methods."""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from .__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/headers.py
+++ b/pyietflib/headers.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """Collection of all pyietflib header parsing methods."""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from .__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/iso8601/__init__.py
+++ b/pyietflib/iso8601/__init__.py
@@ -4,21 +4,8 @@
 times <http://www.iso.org/iso/catalogue_detail?csnumber=40874>`_ parsing
 and formatting.
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 from .time import *
 from .date import *

--- a/pyietflib/iso8601/date.py
+++ b/pyietflib/iso8601/date.py
@@ -4,21 +4,8 @@
 times <http://www.iso.org/iso/catalogue_detail?csnumber=40874>`_ date
 parsing and formatting.
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/iso8601/datetime.py
+++ b/pyietflib/iso8601/datetime.py
@@ -4,21 +4,8 @@
 times <http://www.iso.org/iso/catalogue_detail?csnumber=40874>`_ date
 parsing and formatting.
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/iso8601/time.py
+++ b/pyietflib/iso8601/time.py
@@ -4,21 +4,8 @@
 times <http://www.iso.org/iso/catalogue_detail?csnumber=40874>`_ date
 parsing and formatting.
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc2045/__init__.py
+++ b/pyietflib/rfc2045/__init__.py
@@ -4,21 +4,8 @@
 Mail Extensions (MIME) Part One: Format of Internet Message Bodies headers
 parsering and validation.
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 from .contenttype import *
 

--- a/pyietflib/rfc2045/contenttype.py
+++ b/pyietflib/rfc2045/contenttype.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """`Content-Type <http://tools.ietf.org/html/rfc2045>`_"""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc2045/contenttype_iana.py
+++ b/pyietflib/rfc2045/contenttype_iana.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """IANA registered Content-Type type and subtype values."""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc5646/__init__.py
+++ b/pyietflib/rfc5646/__init__.py
@@ -3,21 +3,8 @@
 """`RFC 5646 <http://tools.ietf.org/html/rfc5646>`_ Tags for Identifying
 Languages parser.
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 from .languagetag import *
 from .registry import *

--- a/pyietflib/rfc5646/languagetag.py
+++ b/pyietflib/rfc5646/languagetag.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """`Language Tag <http://tools.ietf.org/html/rfc5646>`_"""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc5646/registry.py
+++ b/pyietflib/rfc5646/registry.py
@@ -2,21 +2,8 @@
 # -*- coding: UTF-8 -*-
 """`RFC 5646 IANA Language Subtag Registry
 <http://tools.ietf.org/html/rfc5646#section-3>`_ reader."""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc5870/__init__.py
+++ b/pyietflib/rfc5870/__init__.py
@@ -3,21 +3,8 @@
 """`RFC 5870 <http://tools.ietf.org/html/rfc5870>`_ A Uniform Resource
 Identifier for Geographic Locations ('geo' URI).
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 from .geouri import *
 

--- a/pyietflib/rfc5870/geouri.py
+++ b/pyietflib/rfc5870/geouri.py
@@ -2,21 +2,8 @@
 # -*- coding: UTF-8 -*-
 """`RFC5870 <http://tools.ietf.org/html/rfc5870>`_ A Uniform Resource
 Identifier for Geographic Locations ('geo' URI)."""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc6350/__init__.py
+++ b/pyietflib/rfc6350/__init__.py
@@ -16,21 +16,8 @@ File Extension
 - .vcf
 - .vcard
 """
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 from .vcard import *
 from .property import *

--- a/pyietflib/rfc6350/parameter.py
+++ b/pyietflib/rfc6350/parameter.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """`vCard Parameter <http://tools.ietf.org/html/rfc6350#section-5>`_"""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc6350/property.py
+++ b/pyietflib/rfc6350/property.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """`vCard Property <http://tools.ietf.org/html/rfc6350#section-6>`_"""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc6350/sample.py
+++ b/pyietflib/rfc6350/sample.py
@@ -1,21 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """Parser for RFC 5646 Tags for Identifying Languages"""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 import ply.lex as lex
 
 # List of token names.   This is always required

--- a/pyietflib/rfc6350/vCard_v4.py
+++ b/pyietflib/rfc6350/vCard_v4.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """Parser for vCard v4 as defined in RFC6350"""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/rfc6350/vcard.py
+++ b/pyietflib/rfc6350/vcard.py
@@ -2,21 +2,8 @@
 # -*- coding: UTF-8 -*-
 """`vCard <http://tools.ietf.org/html/rfc6350>`_ object that contains
 the information in structured form."""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from ..__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/pyietflib/uri_scheme.py
+++ b/pyietflib/uri_scheme.py
@@ -1,21 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 """Collection of all pyietflib URI parsing methods."""
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from .__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,8 @@
 # -*- coding: UTF-8 -*-
 #----------------------------------------------------------------------------
 """IETF RFC media type objects."""
-__author__ = ('Lance Finn Helsten',)
-__version__ = '1.0'
-__copyright__ = """Copyright 2011 Lance Finn Helsten (helsten@acm.org)"""
-__license__ = """
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+from .__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 #----------------------------------------------------------------------------
 """IETF RFC media type objects."""
 
-from .__meta__ import (__version__, __author__, __copyright__, __license__)
+from pyietflib.__meta__ import (__version__, __author__, __copyright__, __license__)
 
 import sys
 if sys.version_info < (3, 2):


### PR DESCRIPTION
It’ll be easier to update project-wide metadata in one file this way.  (No need to change 20 declarations of `__version__`. :wink:  )
